### PR TITLE
Update minimum Java version

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ TODO add table of content
 
 ## Prerequisites
 To get this application running, you'll need
-- Java 8 or higher
+- Java 17 or higher
 - Maven
 - A key for the OpenAI API
 - Docker (optional)


### PR DESCRIPTION
Quarkus 3.7+ requires Java 17 as a minimum version